### PR TITLE
Remove using pattern for resource stream

### DIFF
--- a/FumoSkull/FumoSkull/FumoSkulls.cs
+++ b/FumoSkull/FumoSkull/FumoSkulls.cs
@@ -19,10 +19,8 @@ namespace FumoSkull
 
         private void Awake()
         {
-            using (var stream = typeof(FumoSkulls).Assembly.GetManifestResourceStream("fumoskulls"))
-            {
-                fumoBundle = AssetBundle.LoadFromStream(stream);
-            }
+            var stream = typeof(FumoSkulls).Assembly.GetManifestResourceStream("fumoskulls");
+            fumoBundle = AssetBundle.LoadFromStream(stream);
             fumoBundle.LoadAllAssets();
             fumo = new Harmony("UltraFumosTeam.UltraFumos");
             fumo.PatchAll();


### PR DESCRIPTION
Stream must not be disposed for as long as the associated AssetBundle is alive, as per Unity documentation

https://docs.unity3d.com/ScriptReference/AssetBundle.LoadFromStream.html